### PR TITLE
Add `walkSync` method

### DIFF
--- a/.changeset/wicked-trees-camp.md
+++ b/.changeset/wicked-trees-camp.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": minor
+---
+
+Add `walkSync` export

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,17 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'pnpm'
+          cache: "pnpm"
       - if: ${{ steps.cache-node.outputs.cache-hit != 'true' }}
         run: pnpm install
       - run: pnpm run build
       - run: pnpm run test
       - uses: changesets/action@v1
+        if: github.event_name == "push"
         with:
           publish: pnpm changeset publish
-          commit: '[ci] release'
-          title: '[ci] release'
+          commit: "[ci] release"
+          title: "[ci] release"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,28 @@ A 1.75kB library for enhancing `html`. `ultrahtml` has zero dependencies and is 
 
 The `walk` function provides full control over the AST. It can be used to scan for text, elements, components, or any other validation you might want to do.
 
+> **Note** > `walk` is `async` and **must** be `await`ed. Use `walkSync` if it is guaranteed there are no `async` components in the tree.
+
 ```js
 import { parse, walk, ELEMENT_NODE } from "ultrahtml";
 
 const ast = parse(`<h1>Hello world!</h1>`);
-walk(ast, (node) => {
+await walk(ast, async (node) => {
+  if (node.type === ELEMENT_NODE && node.name === "script") {
+    throw new Error("Found a script!");
+  }
+});
+```
+
+#### `walkSync`
+
+The `walkSync` function is identical to the `walk` function, but is synchronous. This should only be used when it is guaranteed there are no `async` components in the tree.
+
+```js
+import { parse, walkSync, ELEMENT_NODE } from "ultrahtml";
+
+const ast = parse(`<h1>Hello world!</h1>`);
+walkSync(ast, (node) => {
   if (node.type === ELEMENT_NODE && node.name === "script") {
     throw new Error("Found a script!");
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,10 @@ export interface Visitor {
   (node: Node, parent?: Node, index?: number): void | Promise<void>;
 }
 
+export interface VisitorSync {
+  (node: Node, parent?: Node, index?: number): void;
+}
+
 class Walker {
   constructor(private callback: Visitor) {}
   async visit(node: Node, parent?: Node, index?: number): Promise<void> {
@@ -184,6 +188,19 @@ class Walker {
         promises.push(this.visit(child, node, i));
       }
       await Promise.all(promises);
+    }
+  }
+}
+
+class WalkerSync {
+  constructor(private callback: VisitorSync) {}
+  visit(node: Node, parent?: Node, index?: number): void {
+    this.callback(node, parent, index);
+    if (Array.isArray(node.children)) {
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        this.visit(child, node, i);
+      }
     }
   }
 }
@@ -245,6 +262,11 @@ export function html(tmpl: TemplateStringsArray, ...vals: any[]) {
 
 export function walk(node: Node, callback: Visitor): Promise<void> {
   const walker = new Walker(callback);
+  return walker.visit(node);
+}
+
+export function walkSync(node: Node, callback: VisitorSync): void {
+  const walker = new WalkerSync(callback);
   return walker.visit(node);
 }
 


### PR DESCRIPTION
`walk` is async, which is great if you have `async` components. But it's annoying if you just need a `sync` method to scan the AST.

This PR exposes a `walkSync` method.