### PR TITLE
add `resolveAsset` option to `inline` transformer

### DIFF
--- a/.changeset/short-ligers-occur.md
+++ b/.changeset/short-ligers-occur.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Add `resolveAsset` option to the `inline` transformer

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,8 +399,8 @@ export interface Transformer {
 export async function transform(markup: string|Node, transformers: Transformer[] = []): Promise<string> {
   const doc = (typeof markup === 'string') ? parse(markup) : markup;
   let newDoc = doc;
-  for (const transform of transformers) {
-    newDoc = await transform(newDoc);
+  for (const t of transformers) {
+    newDoc = await t(newDoc);
   }
   return render(newDoc)
 }

--- a/src/transformers/inline.ts
+++ b/src/transformers/inline.ts
@@ -1,23 +1,42 @@
-import { walkSync, ELEMENT_NODE, TEXT_NODE, Node } from "../index.js";
+import { walkSync, ELEMENT_NODE, TEXT_NODE, Node, ElementNode } from "../index.js";
 import { querySelectorAll, specificity } from "../selector.js";
 import { compile } from "stylis";
 
-export default function inline() {
-  return (doc: Node): Node => {
+export interface InlineOptions {
+  resolveAsset: (node: ElementNode) => void|string|Promise<string|void>;
+}
+export default function inline(opts?: InlineOptions) {
+  return async (doc: Node): Promise<Node> => {
     const style: string[] = [];
     const actions: (() => void)[] = [];
+    const promises: Promise<void>[] = [];
     walkSync(doc, (node: Node, parent?: Node) => {
-      if (node.type === ELEMENT_NODE && node.name === "style") {
-        style.push(
-          node.children
-            .map((c: Node) => (c.type === TEXT_NODE ? c.value : ""))
-            .join("")
-        );
-        actions.push(() => {
-          parent!.children = parent!.children.filter((c: Node) => c !== node);
-        });
+      if (node.type === ELEMENT_NODE) {
+        if (opts?.resolveAsset && node.name === 'link' && node.attributes.rel === 'stylesheet') {
+          // ensure order is maintained
+          const i = style.push('');
+          promises.push(Promise.resolve(opts.resolveAsset(node)).then(css => {
+            if (css) {
+              style[i] = css;
+              actions.push(() => {
+                parent!.children = parent!.children.filter((c: Node) => c !== node);
+              });
+            }
+          }))
+        }
+        if (node.name === "style") {
+          style.push(
+            node.children
+              .map((c: Node) => (c.type === TEXT_NODE ? c.value : ""))
+              .join("")
+          );
+          actions.push(() => {
+            parent!.children = parent!.children.filter((c: Node) => c !== node);
+          });
+        }
       }
     });
+    await Promise.all(promises);
     for (const action of actions) {
       action();
     }
@@ -72,4 +91,7 @@ export default function inline() {
     }
     return doc;
   };
+}
+function isHttpURL(href: string): boolean {
+  return href.startsWith('http://') || href.startsWith('https://');
 }

--- a/test/transformers/inline.test.tsx
+++ b/test/transformers/inline.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { h, Fragment, transform } from '../../src/index'
-import inline from '../../src/transformers/inline';
+import { h, Fragment, transform } from "../../src/index";
+import inline from "../../src/transformers/inline";
+import { setTimeout as sleep } from 'timers/promises'
 
 describe("inline", () => {
   it("works with a simple input", async () => {
@@ -20,24 +21,115 @@ describe("inline", () => {
     const output = await transform(input, [inline()]);
     expect(output).toEqual(`<div style="color:blue;">Hello world</div>`);
   });
-})
+});
 
 describe("inline jsx", () => {
   it("works with a simple input", async () => {
-    const input = <><div>Hello world</div><style>{`div { color: red; }`}</style></>;
+    const input = (
+      <>
+        <div>Hello world</div>
+        <style>{`div { color: red; }`}</style>
+      </>
+    );
     const output = await transform(input, [inline()]);
     expect(output).toEqual(`<div style="color:red;">Hello world</div>`);
   });
 
   it("works with multiple inputs", async () => {
-    const input = <><div>Hello world</div><style>{`div { color: green; }`}</style><style>{`div { color: red; }`}</style></>;
+    const input = (
+      <>
+        <div>Hello world</div>
+        <style>{`div { color: green; }`}</style>
+        <style>{`div { color: red; }`}</style>
+      </>
+    );
     const output = await transform(input, [inline()]);
     expect(output).toEqual(`<div style="color:red;">Hello world</div>`);
   });
 
   it("inline styles override external", async () => {
-    const input = <><div style="color:blue;">Hello world</div><style>{`div { color: red; }`}</style></>;
+    const input = (
+      <>
+        <div style="color:blue;">Hello world</div>
+        <style>{`div { color: red; }`}</style>
+      </>
+    );
     const output = await transform(input, [inline()]);
     expect(output).toEqual(`<div style="color:blue;">Hello world</div>`);
   });
-})
+});
+
+describe("inline link", () => {
+  it("works with sync resolveAsset", async () => {
+    const input = `<link rel="stylesheet" href="/assets/1.css" /><div>Hello world</div>`;
+    const output = await transform(input, [
+      inline({
+        resolveAsset({ attributes: { href } }) {
+          if (href === "/assets/1.css") {
+            return "div{color:red;}";
+          }
+        },
+      }),
+    ]);
+    expect(output).toEqual(`<div style="color:red;">Hello world</div>`);
+  });
+  it("ignores unresolved assets", async () => {
+    const input = `<link rel="stylesheet" href="/assets/1.css"><div>Hello world</div>`;
+    const output = await transform(input, [
+      inline({
+        resolveAsset({ attributes: { href } }) {
+          if (href === "/assets/1.css") {
+            return;
+          }
+        },
+      }),
+    ]);
+    expect(output).toEqual(input);
+  });
+  it("works with async resolveAsset", async () => {
+    const input = `<link rel="stylesheet" href="/assets/1.css" /><div>Hello world</div>`;
+    const output = await transform(input, [
+      inline({
+        async resolveAsset({ attributes: { href } }) {
+          if (href === "/assets/1.css") {
+            return "div{color:red;}";
+          }
+        },
+      }),
+    ]);
+    expect(output).toEqual(`<div style="color:red;">Hello world</div>`);
+  });
+  it("works with multiple inputs", async () => {
+    const input = `<link rel="stylesheet" href="/assets/1.css" /><link rel="stylesheet" href="/assets/2.css" /><div>Hello world</div>`;
+    const output = await transform(input, [
+      inline({
+        resolveAsset({ attributes: { href } }) {
+          if (href === "/assets/1.css") {
+            return "div{color:green;}";
+          }
+          if (href === "/assets/2.css") {
+            return "div{color:red;}";
+          }
+        },
+      }),
+    ]);
+    expect(output).toEqual(`<div style="color:red;">Hello world</div>`);
+  });
+  it("works with multiple inputs and maintains order", async () => {
+    const input = `<link rel="stylesheet" href="/assets/1.css" /><link rel="stylesheet" href="/assets/2.css" /><div>Hello world</div>`;
+    const output = await transform(input, [
+      inline({
+        async resolveAsset({ attributes: { href } }) {
+          if (href === "/assets/1.css") {
+            await sleep(200)
+            return "div{color:green;}";
+          }
+          if (href === "/assets/2.css") {
+            return "div{color:red;}";
+          }
+        },
+      }),
+    ]);
+    expect(output).toEqual(`<div style="color:red;">Hello world</div>`);
+  });
+});


### PR DESCRIPTION
Allow external `link[rel="stylesheet"]` assets to be inlined using the `resolveAsset` option.