### PR TITLE
Add `renderSync` export

### DIFF
--- a/.changeset/cuddly-rivers-film.md
+++ b/.changeset/cuddly-rivers-film.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": minor
+---
+
+Add `renderSync` export


### PR DESCRIPTION
Closes #47. Adds a `renderSync` export. Won't work if any Element has an `async` render function, but that's expected!