### PR TITLE
Allow svg children to self-close

### DIFF
--- a/.changeset/smart-pumpkins-occur.md
+++ b/.changeset/smart-pumpkins-occur.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": minor
+---
+
+Allow elements inside of <svg> to be self-closing for compactness

--- a/.changeset/smart-pumpkins-occur.md
+++ b/.changeset/smart-pumpkins-occur.md
@@ -2,4 +2,4 @@
 "ultrahtml": minor
 ---
 
-Allow elements inside of <svg> to be self-closing for compactness
+Allow elements inside of `<svg>` to be self-closing for compactness

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,6 +387,17 @@ export function walkSync(node: Node, callback: VisitorSync): void {
   return walker.visit(node);
 }
 
+function canSelfClose(node: Node): boolean {
+  if (node.children.length === 0) {
+    let n: Node | undefined = node;
+    while (n = n.parent) {
+      if (n.name === 'svg') return true;
+    }
+  }
+  return false;
+}
+
+
 async function renderElement(node: Node): Promise<string> {
   const { name, attributes = {} } = node;
   const children = await Promise.all(
@@ -398,8 +409,9 @@ async function renderElement(node: Node): Promise<string> {
     return escapeHTML(String(value));
   }
   if (name === Fragment) return children;
-  if (VOID_TAGS.has(name)) {
-    return `<${node.name}${attrs(attributes).value}>`;
+  const isSelfClosing = canSelfClose(node);
+  if (isSelfClosing || VOID_TAGS.has(name)) {
+    return `<${node.name}${attrs(attributes).value}${isSelfClosing ? ' /' : ''}>`;
   }
   return `<${node.name}${attrs(attributes).value}>${children}</${node.name}>`;
 }
@@ -413,8 +425,9 @@ function renderElementSync(node: Node): string {
     return escapeHTML(String(value));
   }
   if (name === Fragment) return children;
-  if (VOID_TAGS.has(name)) {
-    return `<${node.name}${attrs(attributes).value}>`;
+  const isSelfClosing = canSelfClose(node);
+  if (isSelfClosing || VOID_TAGS.has(name)) {
+    return `<${node.name}${attrs(attributes).value}${isSelfClosing ? ' /' : ''}>`;
   }
   return `<${node.name}${attrs(attributes).value}>${children}</${node.name}>`;
 }

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -1,0 +1,15 @@
+import { parse, render, renderSync } from "../src";
+import { describe, expect, it, test } from "vitest";
+
+describe("svg", () => {
+  it("render as self-closing", async () => {
+    const input = `<svg><path d="0 0 0" /></svg>`;
+    const output = await render(parse(input));
+    expect(output).toEqual(input);
+  });
+  it("renderSync as self-closing", async () => {
+    const input = `<svg><path d="0 0 0" /></svg>`;
+    const output = renderSync(parse(input));
+    expect(output).toEqual(input);
+  });
+});


### PR DESCRIPTION
Closes #48.

All children of `<svg>` can be self-closing because they're foreign elements (in the SVG namespace). From my research, it seems that MathML does not support self-closing tags.