### PR TITLE
Allow `inline` to evaluate precomupted media queries

### DIFF
--- a/.changeset/beige-boats-float.md
+++ b/.changeset/beige-boats-float.md
@@ -1,0 +1,17 @@
+---
+"ultrahtml": minor
+---
+
+Add support for static media queries to `ultrahtml/transformers/inline`.
+
+You may now pass an `env` value to the transformer, for example:
+
+```js
+import { transform } from "ultrahtml";
+import inline from "ultrahtml/transformers/inline";
+
+const output = await transform(input, [
+  // Acts as if the screen is 960px wide and 1280px tall
+  inline({ env: { width: 960, height: 1280 } }),
+]);
+```

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "prettier": "^2.5.1",
     "pretty-bytes": "^6.0.0",
     "stylis": "^4.1.2",
+    "media-query-fns": "^2.0.0",
     "typescript": "^4.7.4",
     "vitest": "^0.20.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   globby: ^13.1.2
   gzip-size: ^7.0.0
   markdown-it: ^13.0.1
+  media-query-fns: ^2.0.0
   npm-run-all: ^4.1.5
   parsel-js: ^1.0.2
   prettier: ^2.5.1
@@ -24,6 +25,7 @@ devDependencies:
   globby: 13.1.2
   gzip-size: 7.0.0
   markdown-it: 13.0.1
+  media-query-fns: 2.0.0
   npm-run-all: 4.1.5
   parsel-js: 1.0.2
   prettier: 2.7.1
@@ -1431,6 +1433,18 @@ packages:
 
   /mdurl/1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
+    dev: true
+
+  /media-query-fns/2.0.0:
+    resolution: {integrity: sha512-HAIvh3utK+RMkNT/3Cc3fZuA2WJj4nISBHcmcXuSBaosB3slwl/iVjO/coroelDjOgKFgpe4oAoy7OO2sCgDog==}
+    engines: {node: '>=16.0.0 || ^14.13.1'}
+    dependencies:
+      media-query-parser: 3.0.0-beta.1
+    dev: true
+
+  /media-query-parser/3.0.0-beta.1:
+    resolution: {integrity: sha512-LWNtMYGpFmRnOYWVG0KNHKz8grWc7bHym9KTecl2cU5dzUv50qiafcfqeLmV6t2j4ZhnAWfTcQ++ejjyGvLdsg==}
+    engines: {node: '>=16.0.0 || ^14.13.1'}
     dev: true
 
   /memorystream/0.3.1:

--- a/test/transformers/inline.test.tsx
+++ b/test/transformers/inline.test.tsx
@@ -34,6 +34,44 @@ describe("inline", () => {
       `<div class="cool" style="color:red;">Hello world</div>`
     );
   });
+
+  it("inlines styles when @media is matched", async () => {
+    const input = `<div class="cool">Hello world</div>
+      <style>
+        .cool {
+          color: red;
+        }
+
+        @media (min-width: 960px) {
+          .cool {
+            color: green;
+          }
+        }
+      </style>`;
+    const output = await transform(input, [inline({ env: { width: 961, height: 1280 }})]);
+    expect(output.trim()).toEqual(
+      `<div class="cool" style="color:green;">Hello world</div>`
+    );
+  });
+
+  it("does not inline styles when @media cannot be matched", async () => {
+    const input = `<div class="cool">Hello world</div>
+      <style>
+        .cool {
+          color: red;
+        }
+
+        @media (min-width: 960px) {
+          .cool {
+            color: green;
+          }
+        }
+      </style>`;
+    const output = await transform(input, [inline({ env: { width: 959, height: 1280 }})]);
+    expect(output.trim()).toEqual(
+      `<div class="cool" style="color:red;">Hello world</div>`
+    );
+  });
 });
 
 describe("inline jsx", () => {


### PR DESCRIPTION
Adds `@media` support to `ultrahtml/transformers/inline`.

You may now pass an `env` value to the transformer, for example:

```js
import { transform } from "ultrahtml";
import inline from "ultrahtml/transformers/inline";

const output = await transform(input, [
  // Acts as if the screen is 960px wide and 1280px tall
  inline({ env: { width: 960, height: 1280 } }),
]);
```