### PR TITLE
fix: improve parsing performance

### DIFF
--- a/.changeset/hip-clowns-retire.md
+++ b/.changeset/hip-clowns-retire.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Improve parser performance for attributes

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -88,8 +88,8 @@ s"></div>`);
 	it('with escaped double quote', async () => {
 		const {
 			children: [{ attributes }],
-		} = parse(`<div a="\"never
-more\""></div>`);
-		expect(attributes).toMatchObject({ a: '"never\nmore"' });
+		} = parse(`<div a="&quot;never
+more&quot;"></div>`);
+		expect(attributes).toMatchObject({ a: '&quot;never\nmore&quot;' });
 	});
 });


### PR DESCRIPTION
I was starting to use `astro-opengraph-image` which has a dependency on this project and noticed that the performance of the parser for attributes was bad, because it contained a regular expression that has catastrophic backtracking. I tried to rewrite the attribute parser to a manual one, that has linear time complexity when parsing attributes. 

I also noticed, that one of the tests seems to be incorrect, as quotes inside attributes must be escaped via HTML escaping.