### PR TITLE
docs: remove `render` note

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ walkSync(ast, (node) => {
 
 The `render` function allows you to serialize an AST back into a string.
 
-> **Note**
-> By default, `render` will sanitize your markup, removing any `script` tags. Pass `{ sanitize: false }` to disable this behavior.
-
 ```js
 import { parse, render } from "ultrahtml";
 


### PR DESCRIPTION
This note confused for a bit when I was trying out the library. I believe `render`  sanitizing inputs has been removed since 95c0f73ff46180e438d7f7ca085a7bb0923c6532. Just wanted to remove it so others don't get confused as I did.