### PR TITLE
feat: support `#` in attribute keys for slot shorthand

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ const RAW_TAGS = new Set<string>(['script', 'style']);
 const DOM_PARSER_RE =
 	/(?:<(\/?)([a-zA-Z][a-zA-Z0-9\:-]*)(?:\s([^>]*?))?((?:\s*\/)?)>|(<\!\-\-)([\s\S]*?)(\-\->)|(<\!)([\s\S]*?)(>))/gm;
 
-const ATTR_KEY_IDENTIFIER = /[\@\.a-z0-9_\:\-]/i;
+const ATTR_KEY_IDENTIFIER = /[#@.a-z0-9_:-]/i;
 
 function splitAttrs(str?: string) {
 	let obj: Record<string, string> = {};

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -92,4 +92,10 @@ s"></div>`);
 more&quot;"></div>`);
 		expect(attributes).toMatchObject({ a: '&quot;never\nmore&quot;' });
 	});
+	it('#', async () => {
+		const {
+			children: [{ attributes }],
+		} = parse(`<template #slot></template>`);
+		expect(attributes).toMatchObject({ '#slot': '' });
+	});
 });


### PR DESCRIPTION
Currently, `ATTR_KEY_IDENTIFIER` does not match attributes that begin with `#`. This PR updates the regex so they are correctly matched.

**Vue Template**

```html
<DevOnly>
  <template #fallback>
      Fallback Content
  </template>
</DevOnly>
```

**Before**

```json
{
  "attributes": {
    "fallback": ""
  }
}
```

**After**

```json
{
  "attributes": {
    "#fallback": ""
  }
}
```
