### PR TITLE
chore: disable sourcemaps/minification

### DIFF
--- a/.changeset/good-penguins-pump.md
+++ b/.changeset/good-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Remove sourcemaps and disable minification of published sources.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import { build } from 'esbuild';
@@ -9,6 +10,8 @@ import colors from 'chalk';
 import { generateDtsBundle } from 'dts-bundle-generator';
 
 async function run() {
+  await rm('dist', { recursive: true, force: true });
+
 	const files = await globby(['src/**/*.ts', '!src/env.d.ts']);
 	const output = {};
 	const promises = [];
@@ -21,12 +24,12 @@ async function run() {
 				external: ['../selector.js', '../index.js', './index.js'],
 				bundle: true,
 				format: 'esm',
-				minify: true,
-				sourcemap: 'external',
+				minify: false,
+				sourcemap: false,
 				target: 'node16',
 				platform: 'node',
 			}).then((metadata) => {
-				const file = Object.keys(metadata.metafile.outputs)[1];
+				const file = Object.keys(metadata.metafile.outputs)[0];
 				const size = gzipSizeFromFileSync(file);
 				const b = bytes(size);
 				output[file] = b;


### PR DESCRIPTION
We only need sourcemaps because we minify the sources. Ironically that
means both the tarball and the extracted (install) size is much higher.

If we turn both off, we have somewhat readable code for the tiny
minority of people who want to debug it, and we halve the package size.
