### PR TITLE
perf: skip branding and add skip-ahead to attr parsing

### DIFF
--- a/.changeset/rare-rivers-doubt.md
+++ b/.changeset/rare-rivers-doubt.md
@@ -1,5 +1,0 @@
----
-"ultrahtml": patch
----
-
-Improve performance by using character codes and numeric comparisons.

--- a/.changeset/rare-rivers-doubt.md
+++ b/.changeset/rare-rivers-doubt.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Improve performance by using character codes and numeric comparisons.

--- a/.changeset/seven-flowers-invent.md
+++ b/.changeset/seven-flowers-invent.md
@@ -2,4 +2,4 @@
 "ultrahtml": patch
 ---
 
-Improve parsing performance by using numeric comparisons and selective branding of strings. 
+Improve parsing performance by 1.5x and render performance by 2x. 

--- a/.changeset/seven-flowers-invent.md
+++ b/.changeset/seven-flowers-invent.md
@@ -2,4 +2,4 @@
 "ultrahtml": patch
 ---
 
-Improve parsing perf by skipping ahead to delimiters and avoiding unnecessary branding of strings.
+Improve parsing performance by using numeric comparisons and selective branding of strings. 

--- a/.changeset/seven-flowers-invent.md
+++ b/.changeset/seven-flowers-invent.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Improve parsing perf by skipping ahead to delimiters and avoiding unnecessary branding of strings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,28 @@ const RAW_TAGS = new Set<string>(['script', 'style']);
 const DOM_PARSER_RE =
 	/(?:<(\/?)([a-zA-Z][a-zA-Z0-9\:-]*)(?:\s([^>]*?))?((?:\s*\/)?)>|(<\!\-\-)([\s\S]*?)(\-\->)|(<\!)([\s\S]*?)(>))/gm;
 
-const ATTR_KEY_IDENTIFIER = /[\@\.a-z0-9_\:\-]/i;
+const CHAR_AT = 64; // @
+const CHAR_DOT = 46; // .
+const CHAR_HYPHEN = 45; // -
+const CHAR_COLON = 58; // :
+const CHAR_UNDERSCORE = 95; // _
+const CHAR_EQUALS = 61; // =
+const CHAR_DOUBLE_QUOTE = 34; // "
+const CHAR_SINGLE_QUOTE = 39; // '
+const CHAR_BACKSLASH = 92; // \
+
+function isAttrKeyIdentifier(chr: number): boolean {
+	return (
+		(chr >= 97 && chr <= 122) || // a-z
+		(chr >= 65 && chr <= 90) || // A-Z
+		(chr >= 48 && chr <= 57) || // 0-9
+		chr === CHAR_AT ||
+		chr === CHAR_DOT ||
+		chr === CHAR_HYPHEN ||
+		chr === CHAR_COLON ||
+		chr === CHAR_UNDERSCORE
+	);
+}
 
 function splitAttrs(str?: string) {
 	let obj: Record<string, string> = {};
@@ -113,12 +134,12 @@ function splitAttrs(str?: string) {
 		let currentKey: string | undefined;
 		let currentValue: string = '';
 		let tokenStartIndex: number | undefined;
-		let valueDelimiter: '"' | "'" | undefined;
+		let valueDelimiter: number | undefined;
 		for (let currentIndex = 0; currentIndex < str.length; currentIndex++) {
-			const currentChar = str[currentIndex];
+			const currentChar = str.charCodeAt(currentIndex);
 
 			if (state === 'none') {
-				if (ATTR_KEY_IDENTIFIER.test(currentChar)) {
+				if (isAttrKeyIdentifier(currentChar)) {
 					// add attribute
 					if (currentKey) {
 						obj[currentKey] = currentValue;
@@ -128,13 +149,13 @@ function splitAttrs(str?: string) {
 
 					tokenStartIndex = currentIndex;
 					state = 'key';
-				} else if (currentChar === '=' && currentKey) {
+				} else if (currentChar === CHAR_EQUALS && currentKey) {
 					state = 'value';
 				}
 			} else if (state === 'key') {
-				if (!ATTR_KEY_IDENTIFIER.test(currentChar)) {
+				if (!isAttrKeyIdentifier(currentChar)) {
 					currentKey = str.substring(tokenStartIndex!, currentIndex);
-					if (currentChar === '=') {
+					if (currentChar === CHAR_EQUALS) {
 						state = 'value';
 					} else {
 						state = 'none';
@@ -144,7 +165,7 @@ function splitAttrs(str?: string) {
 				if (
 					currentChar === valueDelimiter &&
 					currentIndex > 0 &&
-					str[currentIndex - 1] !== '\\'
+					str.charCodeAt(currentIndex - 1) !== CHAR_BACKSLASH
 				) {
 					if (valueDelimiter) {
 						currentValue = str.substring(tokenStartIndex!, currentIndex);
@@ -152,7 +173,8 @@ function splitAttrs(str?: string) {
 						state = 'none';
 					}
 				} else if (
-					(currentChar === '"' || currentChar === "'") &&
+					(currentChar === CHAR_DOUBLE_QUOTE ||
+						currentChar === CHAR_SINGLE_QUOTE) &&
 					!valueDelimiter
 				) {
 					tokenStartIndex = currentIndex + 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,6 @@ function splitAttrs(str?: string) {
 		let currentKey: string | undefined;
 		let currentValue: string = '';
 		let tokenStartIndex: number | undefined;
-		let valueDelimiter: number | undefined;
 		for (let currentIndex = 0; currentIndex < str.length; currentIndex++) {
 			const currentChar = str.charCodeAt(currentIndex);
 
@@ -161,25 +160,27 @@ function splitAttrs(str?: string) {
 						state = 'none';
 					}
 				}
-			} else {
-				if (
-					currentChar === valueDelimiter &&
-					currentIndex > 0 &&
-					str.charCodeAt(currentIndex - 1) !== CHAR_BACKSLASH
+			} else if (
+				currentChar === CHAR_DOUBLE_QUOTE ||
+				currentChar === CHAR_SINGLE_QUOTE
+			) {
+				const quote = currentChar === CHAR_DOUBLE_QUOTE ? '"' : "'";
+				const valueStart = currentIndex + 1;
+				let closeIndex = str.indexOf(quote, valueStart);
+				// skip escaped delimiters
+				while (
+					closeIndex > 0 &&
+					str.charCodeAt(closeIndex - 1) === CHAR_BACKSLASH
 				) {
-					if (valueDelimiter) {
-						currentValue = str.substring(tokenStartIndex!, currentIndex);
-						valueDelimiter = undefined;
-						state = 'none';
-					}
-				} else if (
-					(currentChar === CHAR_DOUBLE_QUOTE ||
-						currentChar === CHAR_SINGLE_QUOTE) &&
-					!valueDelimiter
-				) {
-					tokenStartIndex = currentIndex + 1;
-					valueDelimiter = currentChar;
+					closeIndex = str.indexOf(quote, closeIndex + 1);
 				}
+				if (closeIndex === -1) {
+					// unterminated value, so just leave the key with an empty value
+					break;
+				}
+				currentValue = str.substring(valueStart, closeIndex);
+				currentIndex = closeIndex;
+				state = 'none';
 			}
 		}
 		if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,12 +426,15 @@ const ESCAPE_CHARS: Record<string, string> = {
 function escapeHTML(str: string): string {
 	return str.replace(/[&<>]/g, (c) => ESCAPE_CHARS[c] || c);
 }
-export function attrs(attributes: Record<string, string>) {
+function attrsToString(attributes: Record<string, string>): string {
 	let attrStr = '';
 	for (const [key, value] of Object.entries(attributes)) {
 		attrStr += ` ${key}="${value}"`;
 	}
-	return mark(attrStr, [HTMLString, AttrString]);
+	return attrStr;
+}
+export function attrs(attributes: Record<string, string>) {
+	return mark(attrsToString(attributes), [HTMLString, AttrString]);
 }
 export function html(tmpl: TemplateStringsArray, ...vals: any[]) {
 	let buf = '';
@@ -440,7 +443,7 @@ export function html(tmpl: TemplateStringsArray, ...vals: any[]) {
 		const expr = vals[i];
 		if (buf.endsWith('...') && expr && typeof expr === 'object') {
 			buf = buf.slice(0, -3).trimEnd();
-			buf += attrs(expr).value;
+			buf += attrsToString(expr);
 		} else if (expr && expr[AttrString]) {
 			buf = buf.trimEnd();
 			buf += expr.value;
@@ -488,11 +491,11 @@ async function renderElement(node: Node): Promise<string> {
 	if (name === Fragment) return children;
 	const isSelfClosing = canSelfClose(node);
 	if (isSelfClosing || VOID_TAGS.has(name)) {
-		return `<${node.name}${attrs(attributes).value}${
+		return `<${node.name}${attrsToString(attributes)}${
 			isSelfClosing ? ' /' : ''
 		}>`;
 	}
-	return `<${node.name}${attrs(attributes).value}>${children}</${node.name}>`;
+	return `<${node.name}${attrsToString(attributes)}>${children}</${node.name}>`;
 }
 
 function renderElementSync(node: Node): string {
@@ -508,11 +511,11 @@ function renderElementSync(node: Node): string {
 	if (name === Fragment) return children;
 	const isSelfClosing = canSelfClose(node);
 	if (isSelfClosing || VOID_TAGS.has(name)) {
-		return `<${node.name}${attrs(attributes).value}${
+		return `<${node.name}${attrsToString(attributes)}${
 			isSelfClosing ? ' /' : ''
 		}>`;
 	}
-	return `<${node.name}${attrs(attributes).value}>${children}</${node.name}>`;
+	return `<${node.name}${attrsToString(attributes)}>${children}</${node.name}>`;
 }
 
 export function renderSync(node: Node): string {


### PR DESCRIPTION
Depends on #89.

This does two things:

1. Only brand attribute strings on the way out (i.e. when retrieved via the exported `attrs` function)
2. When parsing attribute values, skip ahead to the first unescaped delimiter rather than iterating every character

In some local benchmarks, I saw:

- Render performance bumped by ~40K ops/sec (more than 2x)
- Parse performance bumped by ~3K ops/sec (1.5x)
