### PR TITLE
chore: update node + action pins, bump build target to node22

### DIFF
--- a/.changeset/tidy-moons-brake.md
+++ b/.changeset/tidy-moons-brake.md
@@ -1,0 +1,5 @@
+---
+'ultrahtml': minor
+---
+
+Updates the build target from Node 16 to Node 22. Published code now uses modern syntax like optional chaining (`?.`) directly instead of downleveled equivalents, resulting in slightly smaller output. Node 22 or later is now the supported runtime baseline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     name: Build Packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         id: cache-node
         with:
           node-version: 24
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm run test
-      - uses: changesets/action@v1
+      - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         if: ${{ github.event_name != 'pull_request' }}
         with:
           publish: pnpm changeset publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     name: Build Packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         id: cache-node
         with:
-          node-version: 18
+          node-version: 24
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm run build

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,17 +8,17 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm run format
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,17 +8,17 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm run format
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/package.json
+++ b/package.json
@@ -57,14 +57,14 @@
 	},
 	"license": "MIT",
 	"volta": {
-		"node": "18.20.4"
+		"node": "24.18.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"esbuild"
 		]
 	},
-	"packageManager": "pnpm@10.7.1",
+	"packageManager": "pnpm@10.34.3",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.2",
 		"@changesets/cli": "^2.27.8",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,7 +26,7 @@ async function run() {
 				format: 'esm',
 				minify: false,
 				sourcemap: false,
-				target: 'node16',
+				target: 'node22',
 				platform: 'node',
 			}).then((metadata) => {
 				const file = Object.keys(metadata.metafile.outputs)[0];


### PR DESCRIPTION
Updates all env pins to current versions:

- **CI workflows**: Node 18 → 24 (latest LTS), `checkout` v4→v7, `setup-node` v4→v6, `pnpm/action-setup` v4→v6, `git-auto-commit-action` v5→v7
- **package.json**: volta `18.20.4` → `24.18.0`, packageManager `pnpm@10.7.1` → `10.34.3`
- **Build**: esbuild target `node16` → `node22` — output now emits optional chaining natively instead of downleveled `== null` chains, slightly smaller bundles (`selector.js` 4.28 → 4.22 kB gzip, `sanitize.js` 1.09 kB → 972 B). Minor changeset included.

Verified locally on the new toolchain: frozen-lockfile install, build, 118/118 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)