### PR TITLE
revert: "[ci] release" (#91)

### DIFF
--- a/.changeset/good-penguins-pump.md
+++ b/.changeset/good-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Remove sourcemaps and disable minification of published sources.

--- a/.changeset/rare-rivers-doubt.md
+++ b/.changeset/rare-rivers-doubt.md
@@ -1,0 +1,5 @@
+---
+"ultrahtml": patch
+---
+
+Improve performance by using character codes and numeric comparisons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # ultrahtml
 
-## 1.6.1
-
-### Patch Changes
-
-- 2c51c20: Remove sourcemaps and disable minification of published sources.
-- 0fc2cc1: Improve performance by using character codes and numeric comparisons.
-
 ## 1.6.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ultrahtml",
 	"type": "module",
-	"version": "1.6.1",
+	"version": "1.6.0",
 	"types": "./dist/index.d.ts",
 	"main": "./dist/index.js",
 	"repository": {


### PR DESCRIPTION
Reverts 268ae42 (the squash-merge of #91). That release versioned 1.6.1 but was never published to npm (latest is 1.6.0), so its two changesets vanished without shipping.

Restoring them means the changesets action regenerates #92 as **1.7.0 with all 4 pending changesets**:

- `good-penguins-pump` (patch) — remove sourcemaps, disable minification
- `rare-rivers-doubt` (patch) — charCodeAt attribute computation
- `seven-flowers-invent` (patch) — 1.5x parse / 2x render perf
- `tidy-moons-brake` (minor) — node22 build target

