### PR TITLE
ci: use npm trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: Build Packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push release branch, create GitHub releases
+      pull-requests: write # create/update the release PR
+      id-token: write # npm trusted publishing (OIDC)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -33,5 +37,4 @@ jobs:
           commit: "[ci] release"
           title: "[ci] release"
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switches npm publishing from the (revoked) `NPM_TOKEN` secret to [trusted publishing](https://docs.npmjs.com/trusted-publishers) via OIDC. Both 1.6.1 (#91) and 1.7.0 (#92) failed to publish with `E404` because the token can no longer write to the registry.

- Grants the job `id-token: write` — the pinned `changesets/action@v1.9.0` detects OIDC when `NPM_TOKEN` is absent and uses trusted publishing automatically
- Explicitly grants `contents: write` + `pull-requests: write`, since a `permissions` block replaces the default grants the changesets action relied on to push the release branch and open release PRs
- Removes the `NPM_TOKEN` env (secret is being deleted from the repo)

Requires the trusted publisher to be configured on npmjs.com for `ultrahtml` first: GitHub Actions, repo `natemoo-re/ultrahtml`, workflow `ci.yml`. Provenance comes for free with OIDC publishes.